### PR TITLE
Home settings page

### DIFF
--- a/sites/all/modules/custom/da_malik/da_malik.install
+++ b/sites/all/modules/custom/da_malik/da_malik.install
@@ -19,6 +19,24 @@ function da_malik_enable() {
     module_enable($modules, TRUE);
 	
 }
+
+/**
+ * Implements hook_update_N()
+ * 
+ * Enable debugacademy module and 
+ * revert Theme 2 Blocks Panels Menus feature
+ */
+
+function da_malik_update_7008(&$sandbox) {
+  /*enable new debugacademy module*/
+  $modules = array('debugacademy');
+  module_enable($modules, TRUE);
+  
+  /*revert theme 2 blocks panels menus feature*/
+  $module = 'theme2_blocks_panels_menus';
+  features_revert_module($module);
+}
+
 /**
 * Implements hook_update_N
 */

--- a/sites/all/modules/custom/debugacademy/debugacademy.admin.inc
+++ b/sites/all/modules/custom/debugacademy/debugacademy.admin.inc
@@ -1,0 +1,303 @@
+<?php
+
+/**
+ * @file
+ * Admin page to update content on debugacademy theme2 homepage.
+ */
+
+/**
+ * System settings form to manage theme 2 homepage content.
+ */
+function debugacademy_admin_settings() {
+  $form['description'] = array(
+    '#markup' => '<p>' . t('Form to modify Debug Academy Theme 2 Homepage content.') . '</p>',
+  );
+
+  /*Main content on homepage*/
+  $form['main_section'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Main Section Content'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['main_section']['debugacademy_main_text'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Main Header'),
+    '#description' => t('Main text to grab attention.'),
+    '#default_value' => variable_get('debugacademy_main_text', ''),
+    '#required' => TRUE,
+  );
+  
+  /*Orange hire popup*/
+  $form['main_section']['debugacademy_hire_popup'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Small side popup'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );  
+  $form['main_section']['debugacademy_hire_popup']['debugacademy_hire_pop_title'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Popup title'),
+    '#description' => t('Attention grabbing one-liner for side popup'),
+    '#default_value' => variable_get('debugacademy_hire_pop_title', 'Hire our next class to work on YOUR project'),
+    '#required' => TRUE,
+  );
+  $form['main_section']['debugacademy_hire_popup']['debugacademy_hire_pop_body'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Popup body'),
+    '#description' => t('Small popup on right side of main page.'),
+    '#default_value' => variable_get('debugacademy_hire_pop_body', 'Client projects are led by the teacher, a full-time senior developer.'),
+    '#required' => TRUE,
+  );
+
+  /*Student Pane Content*/
+  $form['main_section']['debugacademy_student_pane'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Student content pane'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );  
+  $form['main_section']['debugacademy_student_pane']['debugacademy_student_pane_line_one'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Student pane line one'),
+    '#description' => t('First line in student pane'),
+    '#default_value' => variable_get('debugacademy_student_pane_line_one', 'Only teach highly in-demand technologies.<br>Re-assess curriculum regularly.'),
+    '#required' => TRUE,
+  );
+  $form['main_section']['debugacademy_student_pane']['debugacademy_student_pane_line_two'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Student pane line two'),
+    '#description' => t('Second line in student pane'),
+    '#default_value' => variable_get('debugacademy_student_pane_line_two', 'Keep class sizes very small: 5-10 students per class.'),
+    '#required' => TRUE,
+  );
+  $form['main_section']['debugacademy_student_pane']['debugacademy_student_pane_line_three'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Student pane line three'),
+    '#description' => t('Third line in student pane'),
+    '#default_value' => variable_get('debugacademy_student_pane_line_three', 'Curriculum is customized mid-way per-student.'),
+    '#required' => TRUE,
+  );
+  
+  /*Employer Pane Content*/
+  $form['main_section']['debugacademy_employer_pane'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Employer content pane'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );  
+  $form['main_section']['debugacademy_employer_pane']['debugacademy_employer_pane_line_one'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Employer pane line one'),
+    '#description' => t('First line in employer pane'),
+    '#default_value' => variable_get('debugacademy_employer_pane_line_one', 'Only teach highly in-demand technologies.<br>Re-assess curriculum regularly.'),
+    '#required' => TRUE,
+  );
+  $form['main_section']['debugacademy_employer_pane']['debugacademy_employer_pane_line_two'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Employer pane line two'),
+    '#description' => t('Second line in employer pane'),
+    '#default_value' => variable_get('debugacademy_employer_pane_line_two', 'Keep class sizes very small: 5-10 employers per class.'),
+    '#required' => TRUE,
+  );
+  $form['main_section']['debugacademy_employer_pane']['debugacademy_employer_pane_line_three'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Employer pane line three'),
+    '#description' => t('Third line in employer pane'),
+    '#default_value' => variable_get('debugacademy_employer_pane_line_three', 'Curriculum is customized mid-way per-employer.'),
+    '#required' => TRUE,
+  );
+  
+  /*Tabbed Section*/
+  $form['tabbed_section'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Tabbed Section'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );  
+  
+  /*First tab*/
+  $form['tabbed_section']['debugacademy_tab_one_pane'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('First tab content'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );  
+  $form['tabbed_section']['debugacademy_tab_one_pane']['debugacademy_tab_one_pane_title'] = array(
+    '#type' => 'textfield',
+    '#title' => t('First tab title'),
+    '#description' => t('Title of the first tab in the four-tab section'),
+    '#default_value' => variable_get('debugacademy_tab_one_pane_title', 'What are we teaching next?'),
+    '#required' => TRUE,
+  );
+  $form['tabbed_section']['debugacademy_tab_one_pane']['debugacademy_tab_one_pane_body'] = array(
+    '#type' => 'textarea',
+    '#title' => t('First tab body'),
+    '#description' => t('Body of first tab in the four-tab section'),
+    '#default_value' => variable_get('debugacademy_tab_one_pane_body', 'This semester we will be teaching Drupal 7 development. 
+						Students will learn how to be a valuable member of an enterprise-level Drupal development team. Your teacher currently works 
+						on some of the largest Drupal websites in the world, and you will develop the same way his team does. You will be a great asset 
+						to any Drupal development team!'),
+    '#required' => TRUE,
+  );
+
+  /*Second tab*/
+  $form['tabbed_section']['debugacademy_tab_two_pane'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Second tab content'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );  
+  $form['tabbed_section']['debugacademy_tab_two_pane']['debugacademy_tab_two_pane_title'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Second tab title'),
+    '#description' => t('Title of the second tab in the four-tab section'),
+    '#default_value' => variable_get('debugacademy_tab_two_pane_title', 'What happens when the class is over?'),
+    '#required' => TRUE,
+  );
+  $form['tabbed_section']['debugacademy_tab_two_pane']['debugacademy_tab_two_pane_body'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Second tab body'),
+    '#description' => t('Body of second tab in the four-tab section'),
+    '#default_value' => variable_get('debugacademy_tab_two_pane_body', 'This course will take approximately 14 weeks. After the 
+						course, we will not teach another class for 3 weeks - your teacher\'s job in that time is to help you get 
+						paid work, and be available for questions to make your career transition smoother. This is appealing to 
+						employers - they will hire you, and you have your network as a resource for advanced questions.'),
+    '#required' => TRUE,
+  );
+ 
+  /*Third tab*/
+  $form['tabbed_section']['debugacademy_tab_three_pane'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Third tab content'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );  
+  $form['tabbed_section']['debugacademy_tab_three_pane']['debugacademy_tab_three_pane_title'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Third tab title'),
+    '#description' => t('Title of the third tab in the four-tab section'),
+    '#default_value' => variable_get('debugacademy_tab_three_pane_title', 'Where is the next class located?'),
+    '#required' => TRUE,
+  );
+  $form['tabbed_section']['debugacademy_tab_three_pane']['debugacademy_tab_three_pane_body'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Third tab body'),
+    '#description' => t('Body of third tab in the four-tab section'),
+    '#default_value' => variable_get('debugacademy_tab_three_pane_body', 'The class will be held in Fairfax, VA - 
+						near Washington, D.C. Graduates will be well placed to score a great job with the active D.C. Drupal community.'),
+    '#required' => TRUE,
+  );
+  
+  /*Fourth tab*/
+  $form['tabbed_section']['debugacademy_tab_four_pane'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Fourth tab content'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );  
+  $form['tabbed_section']['debugacademy_tab_four_pane']['debugacademy_tab_four_pane_title'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Fourth tab title'),
+    '#description' => t('Title of the fourth tab in the four-tab section'),
+    '#default_value' => variable_get('debugacademy_tab_four_pane_title', 'What are the payment options?'),
+    '#required' => TRUE,
+  );
+  $form['tabbed_section']['debugacademy_tab_four_pane']['debugacademy_tab_four_pane_body'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Fourth tab body'),
+    '#description' => t('Body of fourth tab in the four-tab section'),
+    '#default_value' => variable_get('debugacademy_tab_four_pane_body', 'Coming soon.'),
+    '#required' => TRUE,
+  );
+  
+  /*Banners*/
+  $form['banners'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Banners with attention grabbing headlines'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );  
+  $form['banners']['debugacademy_banner_one_headline'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Banner one headline'),
+    '#description' => t('Headline for the first banner.'),
+    '#default_value' => variable_get('debugacademy_banner_one_headline', 'JOIN THE MOVEMENT'),
+    '#required' => TRUE,
+  );
+  $form['banners']['debugacademy_banner_two_headline'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Banner two headline'),
+    '#description' => t('Headline for the second banner.'),
+    '#default_value' => variable_get('debugacademy_banner_two_headline', 'PREVIOUS GRADUATE STATISTICS'),
+    '#required' => TRUE,
+  );
+  
+  /*How Debug Academy is Different*/
+  $form['different'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('How Debug Academy is Different'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );  
+  $form['different']['debugacademy_different_intro'] = array(
+    '#type' => 'textarea',
+    '#title' => t('How Debug Academy is Different'),
+    '#description' => t('Small paragraph on what separates Debug Academy from similar programs.'),
+    '#default_value' => variable_get('debugacademy_different_intro', 'Our personalized approach to teaching allows us to cater to individual student
+						strengths and interests. Students are part of a real development team working on real projects. They leave the class with
+						a working portfolio and applied experience on a software project lead by a senior developer.'),
+    '#required' => TRUE,
+  );
+  $form['different']['debugacademy_different_bullets'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Bulleted list of how Debug Academy is different'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+
+  $form['different']['debugacademy_different_bullets']['debugacademy_different_bullet_one'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Bullet One'),
+    '#description' => t('Bullet one on how Debug Academy is different'),
+    '#default_value' => variable_get('debugacademy_different_bullet_one', 'Bullet one'),
+    '#required' => TRUE,
+  );
+  $form['different']['debugacademy_different_bullets']['debugacademy_different_bullet_two'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Bullet Two'),
+    '#description' => t('Bullet two on how Debug Academy is different'),
+    '#default_value' => variable_get('debugacademy_different_bullet_two', 'Bullet two'),
+    '#required' => TRUE,
+  );
+  $form['different']['debugacademy_different_bullets']['debugacademy_different_bullet_three'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Bullet Three'),
+    '#description' => t('Bullet three on how Debug Academy is different'),
+    '#default_value' => variable_get('debugacademy_different_bullet_three', 'Bullet three'),
+    '#required' => TRUE,
+  );
+  $form['different']['debugacademy_different_bullets']['debugacademy_different_bullet_four'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Bullet Four'),
+    '#description' => t('Bullet four on how Debug Academy is different'),
+    '#default_value' => variable_get('debugacademy_different_bullet_four', 'Bullet four'),
+    '#required' => TRUE,
+  );
+  $form['different']['debugacademy_different_bullets']['debugacademy_different_bullet_five'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Bullet Five'),
+    '#description' => t('Bullet five on how Debug Academy is different'),
+    '#default_value' => variable_get('debugacademy_different_bullet_five', 'Bullet five'),
+    '#required' => TRUE,
+  );
+  $form['different']['debugacademy_different_bullets']['debugacademy_different_bullet_six'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Bullet Six'),
+    '#description' => t('Bullet six on how Debug Academy is different'),
+    '#default_value' => variable_get('debugacademy_different_bullet_six', 'Bullet six'),
+    '#required' => TRUE,
+  );
+
+ return system_settings_form($form);
+}

--- a/sites/all/modules/custom/debugacademy/debugacademy.admin.inc
+++ b/sites/all/modules/custom/debugacademy/debugacademy.admin.inc
@@ -24,7 +24,7 @@ function debugacademy_admin_settings() {
     '#type' => 'textfield',
     '#title' => t('Main Header'),
     '#description' => t('Main text to grab attention.'),
-    '#default_value' => variable_get('debugacademy_main_text', ''),
+    '#default_value' => variable_get('debugacademy_main_text', '<h1>Graduate with a career,<br /><strong>Not loans.</strong></h1>'),
     '#required' => TRUE,
   );
   

--- a/sites/all/modules/custom/debugacademy/debugacademy.admin.inc
+++ b/sites/all/modules/custom/debugacademy/debugacademy.admin.inc
@@ -90,21 +90,21 @@ function debugacademy_admin_settings() {
     '#type' => 'textfield',
     '#title' => t('Employer pane line one'),
     '#description' => t('First line in employer pane'),
-    '#default_value' => variable_get('debugacademy_employer_pane_line_one', 'Only teach highly in-demand technologies.<br>Re-assess curriculum regularly.'),
+    '#default_value' => variable_get('debugacademy_employer_pane_line_one', 'Have your project completed by our students.<br/>On time, within budget.'),
     '#required' => TRUE,
   );
   $form['main_section']['debugacademy_employer_pane']['debugacademy_employer_pane_line_two'] = array(
     '#type' => 'textfield',
     '#title' => t('Employer pane line two'),
     '#description' => t('Second line in employer pane'),
-    '#default_value' => variable_get('debugacademy_employer_pane_line_two', 'Keep class sizes very small: 5-10 employers per class.'),
+    '#default_value' => variable_get('debugacademy_employer_pane_line_two', 'Gauge student employment readiness.'),
     '#required' => TRUE,
   );
   $form['main_section']['debugacademy_employer_pane']['debugacademy_employer_pane_line_three'] = array(
     '#type' => 'textfield',
     '#title' => t('Employer pane line three'),
     '#description' => t('Third line in employer pane'),
-    '#default_value' => variable_get('debugacademy_employer_pane_line_three', 'Curriculum is customized mid-way per-employer.'),
+    '#default_value' => variable_get('debugacademy_employer_pane_line_three', 'Employer point three.'),
     '#required' => TRUE,
   );
   
@@ -134,10 +134,7 @@ function debugacademy_admin_settings() {
     '#type' => 'textarea',
     '#title' => t('First tab body'),
     '#description' => t('Body of first tab in the four-tab section'),
-    '#default_value' => variable_get('debugacademy_tab_one_pane_body', 'This semester we will be teaching Drupal 7 development. 
-						Students will learn how to be a valuable member of an enterprise-level Drupal development team. Your teacher currently works 
-						on some of the largest Drupal websites in the world, and you will develop the same way his team does. You will be a great asset 
-						to any Drupal development team!'),
+    '#default_value' => variable_get('debugacademy_tab_one_pane_body', 'This semester we will be teaching Drupal 7 development. Students will learn how to be a valuable member of an enterprise-level Drupal development team. Your teacher currently works on some of the largest Drupal websites in the world, and you will develop the same way his team does. You will be a great asset to any Drupal development team!'),
     '#required' => TRUE,
   );
 
@@ -159,10 +156,7 @@ function debugacademy_admin_settings() {
     '#type' => 'textarea',
     '#title' => t('Second tab body'),
     '#description' => t('Body of second tab in the four-tab section'),
-    '#default_value' => variable_get('debugacademy_tab_two_pane_body', 'This course will take approximately 14 weeks. After the 
-						course, we will not teach another class for 3 weeks - your teacher\'s job in that time is to help you get 
-						paid work, and be available for questions to make your career transition smoother. This is appealing to 
-						employers - they will hire you, and you have your network as a resource for advanced questions.'),
+    '#default_value' => variable_get('debugacademy_tab_two_pane_body', 'This course will take approximately 14 weeks. After the course, we will not teach another class for 3 weeks - your teacher\'s job in that time is to help you get paid work, and be available for questions to make your career transition smoother. This is appealing to employers - they will hire you, and you have your network as a resource for advanced questions.'),
     '#required' => TRUE,
   );
  
@@ -184,8 +178,7 @@ function debugacademy_admin_settings() {
     '#type' => 'textarea',
     '#title' => t('Third tab body'),
     '#description' => t('Body of third tab in the four-tab section'),
-    '#default_value' => variable_get('debugacademy_tab_three_pane_body', 'The class will be held in Fairfax, VA - 
-						near Washington, D.C. Graduates will be well placed to score a great job with the active D.C. Drupal community.'),
+    '#default_value' => variable_get('debugacademy_tab_three_pane_body', 'The class will be held in Fairfax, VA - near Washington, D.C. Graduates will be well placed to score a great job with the active D.C. Drupal community.'),
     '#required' => TRUE,
   );
   
@@ -244,9 +237,7 @@ function debugacademy_admin_settings() {
     '#type' => 'textarea',
     '#title' => t('How Debug Academy is Different'),
     '#description' => t('Small paragraph on what separates Debug Academy from similar programs.'),
-    '#default_value' => variable_get('debugacademy_different_intro', 'Our personalized approach to teaching allows us to cater to individual student
-						strengths and interests. Students are part of a real development team working on real projects. They leave the class with
-						a working portfolio and applied experience on a software project lead by a senior developer.'),
+    '#default_value' => variable_get('debugacademy_different_intro', 'Our personalized approach to teaching allows us to cater to individual student strengths and interests. Students are part of a real development team working on real projects. They leave the class with a working portfolio and applied experience on a software project lead by a senior developer.'),
     '#required' => TRUE,
   );
   $form['different']['debugacademy_different_bullets'] = array(

--- a/sites/all/modules/custom/debugacademy/debugacademy.info
+++ b/sites/all/modules/custom/debugacademy/debugacademy.info
@@ -1,0 +1,3 @@
+name = Debug Academy Module
+description = "For custom debug academy code and updates"
+core = 7.x

--- a/sites/all/modules/custom/debugacademy/debugacademy.install
+++ b/sites/all/modules/custom/debugacademy/debugacademy.install
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Implements hook_enable()
+ */
+
+function debugacademy_enable() {
+
+	/*setting the homepage*/
+ 	$homepage = 'home2';
+	variable_set('site_frontpage', $homepage);
+	
+	/*enabling theme 2 and setting it as the default*/
+	$debug_academy_theme_two = 'debuga_theme2';
+	theme_enable(array($debug_academy_theme_two));
+	variable_set('theme_default', $debug_academy_theme_two);
+	
+	/*enabling theme2 blocks panels, nagat, social media links, and simplenews modules*/
+	$modules = array('theme2_blocks_panels_menus','da_nagatahmed', 'social_media_links','simplenews');
+    module_enable($modules, TRUE);
+	
+}

--- a/sites/all/modules/custom/debugacademy/debugacademy.module
+++ b/sites/all/modules/custom/debugacademy/debugacademy.module
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Implements hook_menu().
+ */
+ 
+function debugacademy_menu() {
+	$items = array();
+	
+	$items['admin/config/system/homepage'] = array(
+		'title' => 'Homepage content',
+		'description' => 'Page that offers a single location to modify homepage content',
+		'page callback' => 'drupal_get_form',
+		'page arguments' => array('debugacademy_admin_settings'),
+		'access arguments' => array('administer homepage settings'),
+		'file' => 'debugacademy.admin.inc',
+	);
+	
+	return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+
+function debugacademy_permission() {
+  return array(
+    'administer homepage settings' => array(
+      'title' => t('Administer Homepage Content'),
+      'description' => t('Perform content updates on Debug Academy Theme 2 homepage'),
+    ),
+  );
+}

--- a/sites/all/modules/theme2_blocks_panels_menus/theme2_blocks_panels_menus.ctools_content.inc
+++ b/sites/all/modules/theme2_blocks_panels_menus/theme2_blocks_panels_menus.ctools_content.inc
@@ -19,8 +19,10 @@ function theme2_blocks_panels_menus_default_ctools_custom_content() {
   $content->category = '';
   $content->settings = array(
     'admin_title' => '',
-    'title' => 'What happens when the class is over?',
-    'body' => '<h2 class="tab-header">What happens when the class is over?</h2><p>This course will take approximately 14 weeks. After the course, we will not teach another class for 3 weeks -- your teacher\'s job in that time is to help you get paid work, and be available for questions to make your career transition smoother. This is appealing to employers - they will hire you, and you have your network as a resource for advanced questions.</p><a href="http://www.w3schools.com/" id="class-over" target="_blank">SEE MORE DETAIL<img src="/sites/all/themes/debuga_theme2/images/more-detail.png"></a>',
+    'title' => variable_get('debugacademy_tab_two_pane_title'),
+    'body' => '<h2 class="tab-header">'.variable_get('debugacademy_tab_two_pane_title').
+			  '</h2><p>'.variable_get('debugacademy_tab_two_pane_body').
+			  '</p><a href="http://www.w3schools.com/" id="class-over" target="_blank">SEE MORE DETAIL<img src="/sites/all/themes/debuga_theme2/images/more-detail.png"></a>',
     'format' => 'html',
     'substitute' => 1,
   );
@@ -52,7 +54,10 @@ function theme2_blocks_panels_menus_default_ctools_custom_content() {
   $content->settings = array(
     'admin_title' => '',
     'title' => 'EMPLOYERS',
-    'body' => '<p class="left-padding right-padding">Only teach highly in-demand technologies.<br>Re-assess curriculum regularly.</p><p class="left-padding right-padding">Keep class sizes very small: 5-10 students per class.</p><p class="left-padding right-padding">Curriculum is customized mid-way per-student.</p><a href="www.cnn.com" id="hire-class">Hire our Class<img src="/sites/all/themes/debuga_theme2/images/hire-class-button.png"></a>',
+    'body' => '<p class="left-padding right-padding">'.variable_get('debugacademy_employer_pane_line_one').
+	'</p><p class="left-padding right-padding">'.variable_get('debugacademy_employer_pane_line_two').
+	'</p><p class="left-padding right-padding">'.variable_get('debugacademy_employer_pane_line_three').
+	'</p><a href="www.cnn.com" id="hire-class">Hire our Class<img src="/sites/all/themes/debuga_theme2/images/hire-class-button.png"></a>',
     'format' => 'html',
     'substitute' => 1,
   );
@@ -83,8 +88,8 @@ function theme2_blocks_panels_menus_default_ctools_custom_content() {
   $content->category = '';
   $content->settings = array(
     'admin_title' => '',
-    'title' => 'Hire our next class to work on YOUR project',
-    'body' => '<p>Client projects are led by the teacher, a full-time senior developer.</p>',
+    'title' => variable_get('debugacademy_hire_pop_title',''),
+    'body' => '<p>'.variable_get('debugacademy_hire_pop_body','').'</p>',
     'format' => 'html',
     'substitute' => 1,
   );
@@ -100,7 +105,13 @@ function theme2_blocks_panels_menus_default_ctools_custom_content() {
   $content->settings = array(
     'admin_title' => '',
     'title' => 'HOW WE\'RE DIFFERENT',
-    'body' => '<hr class="hr-light" id="diff-hr"><p class="left">Debug Society is the best in the world wooot wooot forever and ever. Debug Society is the best in the world wooot wooot forever and ever. Debug Society is the best in the world wooot wooot forever and ever.</p><ul><li>We\'re the best ever seriously we are we are we are we are</li><li>We\'re the best all the time</li><li>We\'re the best yesterday we are</li><li>We\'re the best today</li><li>We\'re the best tomorrow</li><li>We\'re the best now</li></ul>',
+    'body' => '<hr class="hr-light" id="diff-hr"><p class="left">'.variable_get('debugacademy_different_intro').
+			  '</p><ul><li>'.variable_get('debugacademy_different_bullet_one').
+			  '</li><li>'.variable_get('debugacademy_different_bullet_two').
+			  '</li><li>'.variable_get('debugacademy_different_bullet_three').
+			  '</li><li>'.variable_get('debugacademy_different_bullet_four').
+			  '</li><li>'.variable_get('debugacademy_different_bullet_five').
+			  '</li><li>'.variable_get('debugacademy_different_bullet_six').'</li></ul>',
     'format' => 'html',
     'substitute' => 1,
   );
@@ -115,7 +126,7 @@ function theme2_blocks_panels_menus_default_ctools_custom_content() {
   $content->category = '';
   $content->settings = array(
     'admin_title' => '',
-    'title' => 'JOIN THE MOVEMENT',
+    'title' => variable_get('debugacademy_banner_one_headline'),
     'body' => '<hr><a href="/apply" id="apply-today">APPLY TODAY<img src="/sites/all/themes/debuga_theme2/images/apply-today-button.png"></a>',
     'format' => 'html',
     'substitute' => 1,
@@ -131,8 +142,10 @@ function theme2_blocks_panels_menus_default_ctools_custom_content() {
   $content->category = '';
   $content->settings = array(
     'admin_title' => '',
-    'title' => 'Where is the next class located?',
-    'body' => '<h2 class="tab-header">Where is the next class located?</h2><p>The class will be held in Fairfax, VA - near Washington, D.C. Graduates will be well placed to score a great job with the active D.C. Drupal community.</p><a href="http://www.w3schools.com/" id="next-location" target="_blank">SEE MORE DETAIL<img src="/sites/all/themes/debuga_theme2/images/more-detail.png"></a>',
+    'title' => variable_get('debugacademy_tab_three_pane_title'),
+    'body' => '<h2 class="tab-header">'.variable_get('debugacademy_tab_three_pane_title').
+			  '</h2><p>'.variable_get('debugacademy_tab_three_pane_body').
+			  '</p><a href="http://www.w3schools.com/" id="next-location" target="_blank">SEE MORE DETAIL<img src="/sites/all/themes/debuga_theme2/images/more-detail.png"></a>',
     'format' => 'html',
     'substitute' => 1,
   );
@@ -147,8 +160,10 @@ function theme2_blocks_panels_menus_default_ctools_custom_content() {
   $content->category = '';
   $content->settings = array(
     'admin_title' => '',
-    'title' => 'Payment Information',
-    'body' => '<h2 class="tab-header">Payment Information</h2><p>Here is some payment information</p><a href="http://www.w3schools.com/" id="payment-info" target="_blank">SEE MORE DETAIL<img src="/sites/all/themes/debuga_theme2/images/more-detail.png"></a>',
+    'title' => variable_get('debugacademy_tab_four_pane_title'),
+    'body' => '<h2 class="tab-header">'.variable_get('debugacademy_tab_four_pane_title').
+			  '</h2><p>'.variable_get('debugacademy_tab_four_pane_body').
+			  '</p><a href="http://www.w3schools.com/" id="payment-info" target="_blank">SEE MORE DETAIL<img src="/sites/all/themes/debuga_theme2/images/more-detail.png"></a>',
     'format' => 'html',
     'substitute' => 1,
   );
@@ -163,7 +178,7 @@ function theme2_blocks_panels_menus_default_ctools_custom_content() {
   $content->category = '';
   $content->settings = array(
     'admin_title' => '',
-    'title' => 'PREVIOUS GRADUATE STATISTICS',
+    'title' => variable_get('debugacademy_banner_two_headline'),
     'body' => '<hr><a href="https://debugs.slack.com" id="see-stats-link" target="_blank"><img src="/sites/all/themes/debuga_theme2/images/stats-button-bg.png"></a>',
     'format' => 'html',
     'substitute' => 1,
@@ -180,7 +195,10 @@ function theme2_blocks_panels_menus_default_ctools_custom_content() {
   $content->settings = array(
     'admin_title' => '',
     'title' => 'STUDENTS',
-    'body' => '<p class="left-padding right-padding">Only teach highly in-demand technologies.<br>Re-assess curriculum regularly.</p><p class="left-padding right-padding">Keep class sizes very small: 5-10 students per class.</p><p class="left-padding right-padding">Curriculum is customized mid-way per-student.</p><a href="/apply" id="apply-now">Apply Now<img src="/sites/all/themes/debuga_theme2/images/apply-now-button.png"></a>',
+    'body' => '<p class="left-padding right-padding">'.variable_get('debugacademy_student_pane_line_one').
+			  '</p><p class="left-padding right-padding">'.variable_get('debugacademy_student_pane_line_two').
+			  '</p><p class="left-padding right-padding">'.variable_get('debugacademy_student_pane_line_three').
+			  '</p><a href="/apply" id="apply-now">Apply Now<img src="/sites/all/themes/debuga_theme2/images/apply-now-button.png"></a>',
     'format' => 'html',
     'substitute' => 1,
   );
@@ -195,8 +213,10 @@ function theme2_blocks_panels_menus_default_ctools_custom_content() {
   $content->category = '';
   $content->settings = array(
     'admin_title' => '',
-    'title' => 'What are we teaching next?',
-    'body' => '<h2 class="tab-header">What are we teaching next?</h2><p>This semester we will be teaching Drupal 7 development. Students will learn how to be a valuable member of an enterprise-level Drupal development team. Your teacher currently works on some of the largest Drupal websites in the world, and you will develop the same way his team does. You will be a great asset to any Drupal development team!</p><a href="http://www.w3schools.com/" id="teaching-next" target="_blank">SEE MORE DETAIL<img src="/sites/all/themes/debuga_theme2/images/more-detail.png"></a>',
+    'title' => variable_get('debugacademy_tab_one_pane_title'),
+    'body' => '<h2 class="tab-header">'.variable_get('debugacademy_tab_one_pane_title').
+			  '</h2><p>'.variable_get('debugacademy_tab_one_pane_body').
+			  '</p><a href="http://www.w3schools.com/" id="teaching-next" target="_blank">SEE MORE DETAIL<img src="/sites/all/themes/debuga_theme2/images/more-detail.png"></a>',
     'format' => 'html',
     'substitute' => 1,
   );

--- a/sites/all/modules/theme2_blocks_panels_menus/theme2_blocks_panels_menus.features.defaultconfig.inc
+++ b/sites/all/modules/theme2_blocks_panels_menus/theme2_blocks_panels_menus.features.defaultconfig.inc
@@ -449,7 +449,7 @@ function theme2_blocks_panels_menus_defaultconfig_default_panels_mini() {
     $pane->configuration = array(
       'admin_title' => '',
       'title' => '',
-      'body' => '<h1>Graduate with a career,<br><strong>Not Loans.</strong></h1>',
+      'body' => variable_get('debugacademy_main_text',''),
       'format' => 'html',
       'substitute' => TRUE,
     );

--- a/sites/all/modules/theme2_blocks_panels_menus/theme2_blocks_panels_menus.panels_default.inc
+++ b/sites/all/modules/theme2_blocks_panels_menus/theme2_blocks_panels_menus.panels_default.inc
@@ -236,7 +236,7 @@ function theme2_blocks_panels_menus_default_panels_mini() {
     $pane->configuration = array(
       'admin_title' => '',
       'title' => '',
-      'body' => '<h1>Graduate with a career,<br><strong>Not Loans.</strong></h1>',
+      'body' => variable_get('debugacademy_main_text','<h1>Graduate with a career,<br /><strong>Not loans.</strong></h1>'),
       'format' => 'html',
       'substitute' => TRUE,
     );


### PR DESCRIPTION
So I realized that I didn't provide default text from the variable_get calls from within the custom pane code. The implication is that when you enable the debugacademy module most of the content is blank on the home page. If you go to the settings page I created and just click Save it will populate the homepage with all of the default values I provided. (Should've just provided defaults from both locations)

The settings page is found at debugacademy.com/admin/config/system/homepage, from the admin menu it's Configuration > System > Homepage content.

I tested disabling da_malik after enabling debugacademy and saving the configuration and it looked okay
